### PR TITLE
Fix es_ES translation file charset

### DIFF
--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -13,7 +13,7 @@ msgstr ""
 "Last-Translator: Aitor P. Iturri\n"
 "Language-Team: Spanish (Spain)\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=uft8\n"
+"Content-Type: text/plain; charset=iso-8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 msgid ""


### PR DESCRIPTION
Not sure when gettext started erroring out on that warning, maybe it's a configuration of gettext under Nixpkgs, but still this is a correctness issue.

```
rm -f es_ES.gmo && /nix/store/9a46kza0vbb4vdsdmpzbdc7f31y7hs0i-gettext-0.22.5/bin/msgfmt -c --statistics -o es_ES.gmo es_ES.po
es_ES.po: warning: Charset "uft8" is not a portable encoding name.
                   Message conversion to user's charset might not work.
es_ES.po:6: warning: header field 'Language' still has the initial default value
/nix/store/9a46kza0vbb4vdsdmpzbdc7f31y7hs0i-gettext-0.22.5/bin/msgfmt: present charset "uft8" is not a portable encoding name
make[2]: *** [Makefile:111: es_ES.gmo] Error 1
```

Note that the encoding is *not* UTF-8, even though it declared itself to (almost) be.